### PR TITLE
Fix MonitoRSS brand in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Features:
 - Archive.is links for paywalled content
 - Easy self hosting
 - Free and open source
-- Slash command native – no separate UI like monitorss
+- Slash command native – no separate UI like MonitoRSS
 
 ## Deployment
 


### PR DESCRIPTION
## Summary
- fix minor typo in README brand name

## Testing
- `pnpm exec vitest run` *(fails: intr.inGuild is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684b622b65a88331a7f671811528059e