### PR TITLE
Add feedback command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,7 @@ DISCORD_BOT_TOKEN=
 DEVELOPER_IDS=
 
 # OpenRouter API Key
-OPENROUTER_API_KEY=sk-or-v1-
+OPENROUTER_API_KEY=
+
+# Webhook for feedback messages
+FEEDBACK_WEBHOOK_URL=

--- a/src/commands/chat/feedback-command.ts
+++ b/src/commands/chat/feedback-command.ts
@@ -1,0 +1,34 @@
+import { ChatInputCommandInteraction, PermissionsString } from 'discord.js';
+import fetch from 'node-fetch';
+
+import { EventData } from '../../models/internal-models.js';
+import { InteractionUtils } from '../../utils/index.js';
+import { Command, CommandDeferType } from '../index.js';
+import { env } from '../../utils/env.js';
+
+export class FeedbackCommand implements Command {
+    public names = ['feedback'];
+    public deferType = CommandDeferType.HIDDEN;
+    public requireClientPerms: PermissionsString[] = [];
+
+    public async execute(intr: ChatInputCommandInteraction, _data: EventData): Promise<void> {
+        const message = intr.options.getString('message', true);
+        const webhook = env.FEEDBACK_WEBHOOK_URL;
+
+        if (webhook) {
+            try {
+                await fetch(webhook, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        content: `Feedback from ${intr.user.tag} (${intr.user.id}) in ${intr.guild?.name ?? 'DM'}: ${message}`,
+                    }),
+                });
+            } catch {
+                // ignore errors sending feedback
+            }
+        }
+
+        await InteractionUtils.send(intr, 'Thank you for your feedback!', true);
+    }
+}

--- a/src/commands/chat/index.ts
+++ b/src/commands/chat/index.ts
@@ -3,3 +3,4 @@ export { DevCommand } from './dev-command.js';
 export { FeedCommand } from './feed-command.js';
 export { HelpCommand } from './help-command.js';
 export { InfoCommand } from './info-command.js';
+export { FeedbackCommand } from './feedback-command.js';

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -54,6 +54,21 @@ export const ChatCommandMetadata: {
             },
         ],
     },
+    FEEDBACK: {
+        type: ApplicationCommandType.ChatInput,
+        name: 'feedback',
+        description: 'Send feedback to the developer',
+        dm_permission: true,
+        default_member_permissions: undefined,
+        options: [
+            {
+                type: ApplicationCommandOptionType.String,
+                name: 'message',
+                description: 'The feedback message',
+                required: true,
+            },
+        ],
+    },
     TEST: {
         type: ApplicationCommandType.ChatInput,
         name: 'test',

--- a/src/start-bot.ts
+++ b/src/start-bot.ts
@@ -10,6 +10,7 @@ import {
     InfoCommand,
     CategoryCommand,
     FeedCommand,
+    FeedbackCommand,
 } from './commands/chat/index.js';
 import {
     ChatCommandMetadata,
@@ -71,6 +72,7 @@ async function start(): Promise<void> {
         new DevCommand(),
         new HelpCommand(),
         new InfoCommand(),
+        new FeedbackCommand(),
         new FeedCommand(),
         new CategoryCommand(),
     ];

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -16,5 +16,6 @@ export const env = {
     DISCORD_BOT_TOKEN: getEnvVar('DISCORD_BOT_TOKEN'),
     DEVELOPER_IDS: getEnvVar('DEVELOPER_IDS'),
     OPENROUTER_API_KEY: getEnvVar('OPENROUTER_API_KEY', true),
+    FEEDBACK_WEBHOOK_URL: getEnvVar('FEEDBACK_WEBHOOK_URL', true),
     POSTHOG_API_KEY: getEnvVar('POSTHOG_API_KEY', true),
 };


### PR DESCRIPTION
## Summary
- add optional `FEEDBACK_WEBHOOK_URL` env var
- create `/feedback` slash command for sending feedback to the webhook
- export and register the new command
- update example `.env`

## Testing
- `pnpm run build`
- `npx vitest run` *(fails: intr.inGuild is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684b62cbdde0833194135de95f498cdf