### PR TITLE
feat: better errors

### DIFF
--- a/src/commands/chat/feed-command.ts
+++ b/src/commands/chat/feed-command.ts
@@ -27,6 +27,38 @@ function getShortId(uuid: string): string {
     return uuid.substring(0, 8);
 }
 
+// Helper to format relative time
+function formatRelativeTime(date: Date): string {
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins} minute${diffMins > 1 ? 's' : ''} ago`;
+    if (diffHours < 24) return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    if (diffDays < 7) return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+    return date.toLocaleDateString();
+}
+
+// Helper to detect and convert Twitter/X URLs to Nitter RSS format
+function detectAndConvertTwitterUrl(url: string): { isTwitter: boolean; convertedUrl?: string; username?: string } {
+    const twitterPattern = /^https?:\/\/(www\.)?(twitter\.com|x\.com)\/([a-zA-Z0-9_]+)\/?$/;
+    const match = url.match(twitterPattern);
+    
+    if (match) {
+        const username = match[3];
+        return {
+            isTwitter: true,
+            convertedUrl: `https://nitter.net/${username}/rss`,
+            username: username,
+        };
+    }
+    
+    return { isTwitter: false };
+}
+
 // Validate and normalize language code
 // Allows: 2-char codes (en, es), language-region codes (en-US, es-ES), or 3-char codes (eng, spa)
 function validateLanguageCode(language: string | null): string | null {
@@ -192,6 +224,17 @@ export class FeedCommand implements Command {
                             return;
                         }
 
+                        // Check if this is a Twitter/X profile URL and convert to Nitter RSS
+                        const twitterCheck = detectAndConvertTwitterUrl(url);
+                        let feedUrl = url;
+                        if (twitterCheck.isTwitter) {
+                            feedUrl = twitterCheck.convertedUrl!;
+                            await InteractionUtils.editReply(
+                                intr,
+                                `⚠️ **Twitter/X Profile Detected**\n\nTwitter/X doesn't provide RSS feeds. I've converted this to use Nitter (a Twitter RSS proxy):\n\n**Original:** ${inlineCode(url)}\n**RSS Feed:** ${inlineCode(feedUrl)}\n\n*Note: Nitter instances can be unreliable. If this feed fails, try a different Nitter instance or remove the feed.*`
+                            );
+                        }
+
                         // Ensure the target channel (either specified or current) is valid
                         if (
                             !targetChannel ||
@@ -205,42 +248,38 @@ export class FeedCommand implements Command {
                             return;
                         }
 
-                        // Attempt to add the feed
+                        // Validate feed works before adding (fail early)
+                        let finalNickname = nickname;
                         try {
-                            let finalNickname = nickname;
+                            console.log(`Validating feed: ${feedUrl}`);
+                            const rssParser = getRSSParser();
+                            const feed = await rssParser.parseURL(feedUrl);
+                            
+                            if (!feed || (!feed.items || feed.items.length === 0)) {
+                                await InteractionUtils.editReply(
+                                    intr,
+                                    `❌ **Feed Validation Failed**\n\nThe feed at ${inlineCode(feedUrl)} appears to be empty or invalid. Please check the URL and try again.\n\n*If this is a Twitter/X feed, note that Nitter instances may be down. Try a different Nitter instance or wait and try again later.*\n\n💡 You can test feeds with ${inlineCode('/feed poke')} if you've already added them.`
+                                );
+                                return;
+                            }
 
                             // Auto-nickname if not provided
-                            if (!finalNickname) {
-                                try {
-                                    console.log(`Attempting to auto-nickname feed: ${url}`);
-                                    const rssParser = getRSSParser();
-                                    const feed = await rssParser.parseURL(url);
-                                    if (feed.title) {
-                                        finalNickname = feed.title.trim();
-                                        console.log(`Auto-nickname found: "${finalNickname}"`);
-                                    } else {
-                                        console.warn(
-                                            `Feed at ${url} has no title for auto-nicknaming.`
-                                        );
-                                        // Optional: Set a default or leave as null/handle differently
-                                    }
-                                } catch (parseError) {
-                                    console.error(
-                                        `Error fetching/parsing feed for auto-nickname (${url}):`,
-                                        parseError
-                                    );
-                                    // Decide how to handle error: fail, use default, etc.
-                                    // For now, we'll proceed without a nickname if auto-fetch fails
-                                    await InteractionUtils.editReply(
-                                        intr,
-                                        '⚠️ Could not automatically fetch the feed title. Proceeding without a nickname. You can set one later with `/feed update`.'
-                                        // We don't return here, let the add proceed without nickname
-                                    );
-                                    // If you want to *stop* the addition on error, uncomment below:
-                                    // await InteractionUtils.editReply(intr, '❌ Could not fetch feed title. Please provide a nickname or check the URL.');
-                                    // return;
-                                }
+                            if (!finalNickname && feed.title) {
+                                finalNickname = feed.title.trim();
+                                console.log(`Auto-nickname found: "${finalNickname}"`);
                             }
+                        } catch (parseError: any) {
+                            console.error(`Error validating feed (${feedUrl}):`, parseError);
+                            const errorMsg = parseError?.message || 'Unknown error';
+                            await InteractionUtils.editReply(
+                                intr,
+                                `❌ **Feed Validation Failed**\n\nCould not fetch or parse the RSS feed at ${inlineCode(feedUrl)}.\n\n**Error:** ${codeBlock(errorMsg.substring(0, 500))}\n\nPlease check:\n- The URL is correct and accessible\n- The feed is a valid RSS/Atom feed\n- If this is a Twitter/X feed, the Nitter instance may be down\n\n*Feeds must be valid RSS/Atom feeds. Twitter/X profile URLs are not RSS feeds.*\n\n💡 You can test feeds with ${inlineCode('/feed poke')} if you've already added them.`
+                            );
+                            return;
+                        }
+
+                        // Attempt to add the feed
+                        try {
 
                             let initialSummary: string | null = null;
                             let articleContent: string | null = null;
@@ -249,7 +288,7 @@ export class FeedCommand implements Command {
                             if (summarize) {
                                 try {
                                     const rssParser = getRSSParser();
-                                    const feed = await rssParser.parseURL(url);
+                                    const feed = await rssParser.parseURL(feedUrl);
                                     const firstItem = feed.items?.[0];
 
                                     if (firstItem) {
@@ -278,7 +317,7 @@ export class FeedCommand implements Command {
                                         // Generate summary if any content was fetched
                                         if (articleContent || commentsContent) {
                                             Logger.info(
-                                                `[FeedAdd] Summarizing initial item for ${url}`
+                                                `[FeedAdd] Summarizing initial item for ${feedUrl}`
                                             );
                                             // Use provided language or guild language
                                             const effectiveLanguage = language || await FeedStorageService.getGuildLanguage(intr.guild.id);
@@ -286,7 +325,7 @@ export class FeedCommand implements Command {
                                                 await summarizeContent(
                                                     articleContent,
                                                     commentsContent,
-                                                    firstItem.link || url,
+                                                    firstItem.link || feedUrl,
                                                     effectiveLanguage
                                                 );
                                             if (
@@ -306,7 +345,7 @@ export class FeedCommand implements Command {
                                             }
                                         } else {
                                             Logger.warn(
-                                                `[FeedAdd] No content found to summarize for initial item of ${url}`
+                                                `[FeedAdd] No content found to summarize for initial item of ${feedUrl}`
                                             );
                                             await InteractionUtils.send(
                                                 intr,
@@ -317,7 +356,7 @@ export class FeedCommand implements Command {
                                         }
                                     } else {
                                         Logger.warn(
-                                            `[FeedAdd] No items found in feed ${url} for initial summary.`
+                                            `[FeedAdd] No items found in feed ${feedUrl} for initial summary.`
                                         );
                                         await InteractionUtils.send(
                                             intr,
@@ -328,7 +367,7 @@ export class FeedCommand implements Command {
                                     }
                                 } catch (err: any) {
                                     Logger.error(
-                                        `[FeedAdd] Error fetching/summarizing initial item for ${url}:`,
+                                        `[FeedAdd] Error fetching/summarizing initial item for ${feedUrl}:`,
                                         err
                                     );
                                     await InteractionUtils.send(
@@ -351,7 +390,7 @@ export class FeedCommand implements Command {
                                 | 'recentLinks'
                                 | 'lastSummary'
                             > = {
-                                url: url,
+                                url: feedUrl,
                                 channelId: targetChannel.id,
                                 guildId: intr.guild.id,
                                 nickname: finalNickname,
@@ -1292,6 +1331,115 @@ ${linkLine}${snippet}`;
                             await InteractionUtils.editReply(
                                 intr,
                                 '❌ An error occurred while setting the server language. Please check the logs.'
+                            );
+                        }
+                        break;
+                    }
+                    case 'errors': {
+                        const feedIdentifier = intr.options.getString('feed_id');
+                        const limit = intr.options.getInteger('limit') ?? 10;
+
+                        try {
+                            let targetFeedId: string | undefined;
+                            
+                            if (feedIdentifier) {
+                                const allFeeds = await FeedStorageService.getFeeds(intr.guild.id);
+                                let targetFeed: FeedConfig | undefined = allFeeds.find(
+                                    f =>
+                                        f.id === feedIdentifier ||
+                                        f.nickname?.toLowerCase() === feedIdentifier.toLowerCase()
+                                );
+
+                                if (
+                                    !targetFeed &&
+                                    feedIdentifier.length === 8 &&
+                                    /^[a-f0-9-]+$/.test(feedIdentifier)
+                                ) {
+                                    targetFeed = allFeeds.find(f =>
+                                        f.id.startsWith(feedIdentifier)
+                                    );
+                                }
+
+                                if (!targetFeed) {
+                                    await InteractionUtils.editReply(
+                                        intr,
+                                        `❓ Could not find a feed with ID, Short ID, or Nickname \`${feedIdentifier}\` in this server.`
+                                    );
+                                    return;
+                                }
+
+                                targetFeedId = targetFeed.id;
+                            }
+
+                            const failures = await FeedStorageService.getFeedFailures(
+                                targetFeedId,
+                                intr.guild.id,
+                                limit
+                            );
+
+                            if (failures.length === 0) {
+                                const message = targetFeedId
+                                    ? `✅ No errors found for feed \`${getShortId(targetFeedId)}\` in this server.`
+                                    : `✅ No feed errors found for this server.`;
+                                await InteractionUtils.editReply(intr, message);
+                                return;
+                            }
+
+                            const embed = new EmbedBuilder()
+                                .setTitle(
+                                    targetFeedId
+                                        ? `Feed Errors: ${getShortId(targetFeedId)}`
+                                        : `Feed Errors for This Server`
+                                )
+                                .setColor('Red')
+                                .setTimestamp()
+                                .setFooter({ text: `Showing ${failures.length} most recent error(s)` });
+
+                            const errorFields = failures.slice(0, 25).map((failure, index) => {
+                                const feedName = failure.feedNickname || getShortId(failure.feedId);
+                                const errorMsg = failure.errorMessage || 'Unknown error';
+                                const timeAgo = formatRelativeTime(failure.timestamp);
+                                const statusIcon = failure.ignoreErrors ? '🔇' : '⚠️';
+                                
+                                const urlDisplay = failure.feedUrl.length > 60 
+                                    ? failure.feedUrl.substring(0, 57) + '...' 
+                                    : failure.feedUrl;
+                                
+                                const errorDisplay = errorMsg.length > 600 
+                                    ? errorMsg.substring(0, 597) + '...' 
+                                    : errorMsg;
+                                
+                                let value = `${statusIcon} **${feedName}**\n`;
+                                value += `Feed: \`${getShortId(failure.feedId)}\`\n`;
+                                value += `URL: ${urlDisplay}\n`;
+                                value += `Time: ${timeAgo}\n`;
+                                value += `Consecutive: ${failure.consecutiveFailures}\n`;
+                                value += `Error: ${codeBlock(errorDisplay)}`;
+
+                                if (value.length > 1024) {
+                                    value = value.substring(0, 1021) + '...';
+                                }
+
+                                return {
+                                    name: `Error #${index + 1}`,
+                                    value: value,
+                                };
+                            });
+
+                            embed.addFields(errorFields);
+
+                            if (failures.length > 25) {
+                                embed.setDescription(
+                                    `Showing the 25 most recent errors. Total: ${failures.length}`
+                                );
+                            }
+
+                            await InteractionUtils.editReply(intr, { embeds: [embed] });
+                        } catch (error) {
+                            console.error('Error fetching feed errors:', error);
+                            await InteractionUtils.editReply(
+                                intr,
+                                '❌ An error occurred while fetching feed errors. Please check the logs.'
                             );
                         }
                         break;

--- a/src/commands/metadata.ts
+++ b/src/commands/metadata.ts
@@ -294,6 +294,27 @@ export const ChatCommandMetadata: {
                     },
                 ],
             },
+            {
+                type: ApplicationCommandOptionType.Subcommand,
+                name: 'errors',
+                description: 'View feed errors for this server or a specific feed.',
+                options: [
+                    {
+                        type: ApplicationCommandOptionType.String,
+                        name: 'feed_id',
+                        description: 'The ID or nickname of the feed to view errors for (optional).',
+                        required: false,
+                    },
+                    {
+                        type: ApplicationCommandOptionType.Integer,
+                        name: 'limit',
+                        description: 'Maximum number of errors to show (default: 10, max: 30).',
+                        required: false,
+                        min_value: 1,
+                        max_value: 30,
+                    },
+                ],
+            },
         ],
     },
     CATEGORY: {

--- a/src/scripts/analyze-feed-failures.ts
+++ b/src/scripts/analyze-feed-failures.ts
@@ -1,0 +1,176 @@
+import { desc, eq } from 'drizzle-orm';
+import { db, feedFailures, feeds } from '../db/index.js';
+
+async function analyzeFeedFailures() {
+    try {
+        console.log('Querying last 30 feed failures...\n');
+
+        const failures = await db
+            .select({
+                failureId: feedFailures.id,
+                timestamp: feedFailures.timestamp,
+                errorMessage: feedFailures.errorMessage,
+                feedId: feedFailures.feedId,
+                feedUrl: feeds.url,
+                feedNickname: feeds.nickname,
+                guildId: feeds.guildId,
+                channelId: feeds.channelId,
+                consecutiveFailures: feeds.consecutiveFailures,
+                ignoreErrors: feeds.ignoreErrors,
+            })
+            .from(feedFailures)
+            .innerJoin(feeds, eq(feedFailures.feedId, feeds.id))
+            .orderBy(desc(feedFailures.timestamp))
+            .limit(30);
+
+        if (failures.length === 0) {
+            console.log('No feed failures found in the database.');
+            return;
+        }
+
+        console.log(`Found ${failures.length} failures:\n`);
+        console.log('='.repeat(80));
+
+        const errorPatterns: Map<string, number> = new Map();
+        const feedErrorCounts: Map<string, number> = new Map();
+        const guildErrorCounts: Map<string, number> = new Map();
+
+        failures.forEach((failure, index) => {
+            console.log(`\n[${index + 1}] Failure ID: ${failure.failureId}`);
+            console.log(`  Timestamp: ${failure.timestamp}`);
+            console.log(`  Feed ID: ${failure.feedId}`);
+            console.log(`  Feed URL: ${failure.feedUrl}`);
+            console.log(`  Nickname: ${failure.feedNickname || '(none)'}`);
+            console.log(`  Guild ID: ${failure.guildId}`);
+            console.log(`  Channel ID: ${failure.channelId}`);
+            console.log(`  Consecutive Failures: ${failure.consecutiveFailures}`);
+            console.log(`  Ignore Errors: ${failure.ignoreErrors}`);
+            console.log(`  Error Message: ${failure.errorMessage || '(no message)'}`);
+
+            const errorMsg = failure.errorMessage || 'Unknown error';
+            const errorType = categorizeError(errorMsg);
+            errorPatterns.set(errorType, (errorPatterns.get(errorType) || 0) + 1);
+
+            const feedKey = `${failure.feedUrl} (${failure.feedId})`;
+            feedErrorCounts.set(feedKey, (feedErrorCounts.get(feedKey) || 0) + 1);
+
+            guildErrorCounts.set(failure.guildId, (guildErrorCounts.get(failure.guildId) || 0) + 1);
+        });
+
+        console.log('\n' + '='.repeat(80));
+        console.log('\nERROR PATTERN ANALYSIS:');
+        console.log('-'.repeat(80));
+        const sortedPatterns = Array.from(errorPatterns.entries()).sort((a, b) => b[1] - a[1]);
+        sortedPatterns.forEach(([pattern, count]) => {
+            console.log(`  ${pattern}: ${count} occurrence(s)`);
+        });
+
+        console.log('\n' + '='.repeat(80));
+        console.log('\nFEEDS WITH MOST FAILURES:');
+        console.log('-'.repeat(80));
+        const sortedFeeds = Array.from(feedErrorCounts.entries()).sort((a, b) => b[1] - a[1]);
+        sortedFeeds.slice(0, 10).forEach(([feed, count]) => {
+            console.log(`  ${feed}: ${count} failure(s)`);
+        });
+
+        console.log('\n' + '='.repeat(80));
+        console.log('\nGUILDS WITH MOST FAILURES:');
+        console.log('-'.repeat(80));
+        const sortedGuilds = Array.from(guildErrorCounts.entries()).sort((a, b) => b[1] - a[1]);
+        sortedGuilds.slice(0, 10).forEach(([guildId, count]) => {
+            console.log(`  ${guildId}: ${count} failure(s)`);
+        });
+
+        console.log('\n' + '='.repeat(80));
+        console.log('\nRECOMMENDATIONS:');
+        console.log('-'.repeat(80));
+
+        const networkErrors = sortedPatterns.filter(([p]) =>
+            p.toLowerCase().includes('network') || p.toLowerCase().includes('timeout') || p.toLowerCase().includes('fetch')
+        );
+        const parseErrors = sortedPatterns.filter(([p]) =>
+            p.toLowerCase().includes('parse') || p.toLowerCase().includes('xml') || p.toLowerCase().includes('invalid')
+        );
+        const authErrors = sortedPatterns.filter(([p]) =>
+            p.toLowerCase().includes('401') || p.toLowerCase().includes('403') || p.toLowerCase().includes('unauthorized') || p.toLowerCase().includes('forbidden')
+        );
+
+        if (networkErrors.length > 0) {
+            console.log('  ⚠️  Network/timeout errors detected. Consider:');
+            console.log('     - Increasing timeout values');
+            console.log('     - Adding retry logic with exponential backoff');
+            console.log('     - Checking if feeds are down or blocking requests');
+        }
+
+        if (parseErrors.length > 0) {
+            console.log('  ⚠️  Parse errors detected. Consider:');
+            console.log('     - Validating RSS feed format');
+            console.log('     - Adding better error messages with feed URL');
+            console.log('     - Checking if feed format changed');
+        }
+
+        if (authErrors.length > 0) {
+            console.log('  ⚠️  Authentication errors detected. Consider:');
+            console.log('     - Checking if feeds require authentication');
+            console.log('     - Verifying API keys or tokens');
+        }
+
+        const feedsWithManyFailures = sortedFeeds.filter(([, count]) => count >= 3);
+        if (feedsWithManyFailures.length > 0) {
+            console.log(`  ⚠️  ${feedsWithManyFailures.length} feed(s) have 3+ failures. Consider disabling or investigating.`);
+        }
+
+        console.log('\n  ✅ Consider adding a command to view errors:');
+        console.log('     /feed errors [feed_id] [guild_id]');
+        console.log('     This would help users debug issues faster.');
+
+    } catch (error) {
+        console.error('Error analyzing feed failures:', error);
+        throw error;
+    } finally {
+        await db.$client.end();
+    }
+}
+
+function categorizeError(errorMessage: string): string {
+    const msg = errorMessage.toLowerCase();
+
+    if (msg.includes('timeout') || msg.includes('timed out')) {
+        return 'Timeout';
+    }
+    if (msg.includes('status code 410')) {
+        return 'Gone (410)';
+    }
+    if (msg.includes('status code 404') || msg.includes('not found')) {
+        return 'Not Found (404)';
+    }
+    if (msg.includes('status code 500')) {
+        return 'Server Error (500)';
+    }
+    if (msg.includes('status code 401') || msg.includes('unauthorized')) {
+        return 'Authentication Error (401)';
+    }
+    if (msg.includes('status code 403') || msg.includes('forbidden')) {
+        return 'Permission Error (403)';
+    }
+    if (msg.includes('status code 429') || msg.includes('rate limit')) {
+        return 'Rate Limit (429)';
+    }
+    if (msg.includes('unexpected close tag') || msg.includes('invalid character in entity name') || msg.includes('attribute without value')) {
+        return 'XML Parse Error';
+    }
+    if (msg.includes('unable to parse xml') || msg.includes('feed not recognized')) {
+        return 'Invalid Feed Format';
+    }
+    if (msg.includes('network') || msg.includes('econnreset') || msg.includes('enotfound')) {
+        return 'Network Error';
+    }
+    if (msg.includes('certificate') || msg.includes('ssl') || msg.includes('tls')) {
+        return 'SSL/TLS Error';
+    }
+
+    return 'Other/Unknown';
+}
+
+analyzeFeedFailures().catch(console.error);
+

--- a/src/services/feed-storage-service.ts
+++ b/src/services/feed-storage-service.ts
@@ -1,5 +1,5 @@
 import { subHours } from 'date-fns';
-import { and, asc, count, eq, gte, ne } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gte, ne } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { MAX_RECENT_LINKS } from '../constants/index.js';
 import { db } from '../db/index.js';
@@ -887,6 +887,72 @@ export class FeedStorageService {
         } catch (error) {
             console.error(`Error getting effective language for feed ${feedId}:`, error);
             return null;
+        }
+    }
+
+    /**
+     * Gets feed failure records with feed details.
+     * @param feedId Optional feed ID to filter by
+     * @param guildId Optional guild ID to filter by
+     * @param limit Maximum number of failures to return (default: 30)
+     * @returns Array of failure records with feed information
+     */
+    public static async getFeedFailures(
+        feedId?: string,
+        guildId?: string,
+        limit: number = 30
+    ): Promise<
+        Array<{
+            failureId: number;
+            timestamp: Date;
+            errorMessage: string | null;
+            feedId: string;
+            feedUrl: string;
+            feedNickname: string | null;
+            guildId: string;
+            channelId: string;
+            consecutiveFailures: number;
+            ignoreErrors: boolean;
+        }>
+    > {
+        try {
+            let query = (db as any)
+                .select({
+                    failureId: feedFailures.id,
+                    timestamp: feedFailures.timestamp,
+                    errorMessage: feedFailures.errorMessage,
+                    feedId: feedFailures.feedId,
+                    feedUrl: feeds.url,
+                    feedNickname: feeds.nickname,
+                    guildId: feeds.guildId,
+                    channelId: feeds.channelId,
+                    consecutiveFailures: feeds.consecutiveFailures,
+                    ignoreErrors: feeds.ignoreErrors,
+                })
+                .from(feedFailures)
+                .innerJoin(feeds, eq(feedFailures.feedId, feeds.id));
+
+            const conditions = [];
+            if (feedId) {
+                conditions.push(eq(feedFailures.feedId, feedId));
+            }
+            if (guildId) {
+                conditions.push(eq(feeds.guildId, guildId));
+            }
+
+            if (conditions.length > 0) {
+                query = query.where(and(...conditions));
+            }
+
+            const results = await query.orderBy(desc(feedFailures.timestamp)).limit(limit);
+
+            return results;
+        } catch (error) {
+            console.error(
+                `Error getting feed failures${feedId ? ` for feed ${feedId}` : ''}${guildId ? ` for guild ${guildId}` : ''}:`,
+                error
+            );
+            return [];
         }
     }
 }


### PR DESCRIPTION
- Add /feed errors command to view feed failures for server or specific feed
- Add Twitter/X URL detection and auto-conversion to Nitter RSS format
- Add early feed validation to prevent adding broken feeds
- Add analyze-feed-failures.ts script for debugging feed issues
- Improve error messages with actionable suggestions
- Migrate existing Twitter feeds to Nitter format